### PR TITLE
Make it usable from CLI

### DIFF
--- a/Heatmap/heatmap.gpr.py
+++ b/Heatmap/heatmap.gpr.py
@@ -32,5 +32,5 @@ register(REPORT,
     category=CATEGORY_WEB,
     reportclass='ReportClass',
     optionclass='ReportOptions',
-    report_modes=[REPORT_MODE_GUI],
+    report_modes=[REPORT_MODE_GUI, REPORT_MODE_CLI],
     )


### PR DESCRIPTION
Heatmap used to be called on CLI[1] but not anymore.
See https://gramps-project.org/bugs/view.php?id=13990 : it's not
registered to be used through the CLI.
This restores that feature
    
[1] See https://gramps-project.org/bugs/view.php?id=12813
